### PR TITLE
139 make modal header accept a jsx element instead of image

### DIFF
--- a/Components/Game/GameOver.tsx
+++ b/Components/Game/GameOver.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Image } from "react-native";
 import styled from "styled-components/native";
 import CSSImg from "../../assets/languageIcons/css-3.png";
 import HTMLImg from "../../assets/languageIcons/html-5.png";
@@ -30,7 +31,7 @@ const GameOver = ({ gameSession, category, handlePressHome, handlePressPlayAgain
   const { playHomeMusic } = useSound();
   const [answerTimes, setAnswerTimes] = useState<number[]>([]);
 
-  let categoryImg = "";
+  let categoryImg = HTMLImg;
   let categoryColor: string = "";
 
   if (category === "html") {
@@ -49,6 +50,8 @@ const GameOver = ({ gameSession, category, handlePressHome, handlePressPlayAgain
     categoryImg = TSImg;
     categoryColor = themeColors.categories.typeScript;
   }
+
+  const headerImg = <Image source={categoryImg} style={{ width: 40, height: 40 }} />;
 
   useEffect(() => {
     playHomeMusic();
@@ -78,7 +81,7 @@ const GameOver = ({ gameSession, category, handlePressHome, handlePressPlayAgain
         closeModal={() => setModalIsOpen(false)}
         title={"Game Statistics"}
         headerColor={categoryColor}
-        headerImg={categoryImg}
+        headerImg={headerImg}
       >
         <GameSession gameSession={gameSession} categoryColor={categoryColor} />
       </QuizModal>

--- a/Components/Modal/ModalContainer.tsx
+++ b/Components/Modal/ModalContainer.tsx
@@ -11,7 +11,7 @@ interface Props {
   closeModal: () => void;
   title: string;
   headerColor?: string;
-  headerImg?: string;
+  headerImg?: JSX.Element;
 }
 
 const ModalContainer = ({ height, children, closeModal, title, headerColor, headerImg }: Props) => {

--- a/Components/Modal/ModalHeader.tsx
+++ b/Components/Modal/ModalHeader.tsx
@@ -9,7 +9,7 @@ interface Props {
   title: string;
   closeModal: () => void;
   headerColor?: string;
-  headerImg?: string;
+  headerImg?: JSX.Element;
 }
 
 const ModalHeader = ({ title, closeModal, headerColor, headerImg }: Props) => {
@@ -17,7 +17,7 @@ const ModalHeader = ({ title, closeModal, headerColor, headerImg }: Props) => {
 
   return (
     <Header backgroundColor={headerColor} themeColors={themeColors}>
-      {headerImg && <CategoryImage source={headerImg} />}
+      {headerImg && headerImg}
       <STMText size={25} center styles={{ flex: 1 }} uppercase>
         {title}
       </STMText>
@@ -36,10 +36,5 @@ const Header = styled.View<{ backgroundColor: string; themeColors: colorsModel }
 `;
 
 const CloseButton = styled.TouchableOpacity``;
-
-const CategoryImage = styled.Image`
-  height: 40px;
-  width: 40px;
-`;
 
 export default ModalHeader;

--- a/Components/Modal/QuizModal.tsx
+++ b/Components/Modal/QuizModal.tsx
@@ -10,7 +10,7 @@ interface Props {
   children: ReactNode;
   headerColor?: string;
   modalHeight?: string;
-  headerImg?: string;
+  headerImg?: JSX.Element;
 }
 
 const QuizModal = ({ show, closeModal, title, headerColor, children, modalHeight, headerImg }: Props) => {

--- a/Components/User/UserInfo.tsx
+++ b/Components/User/UserInfo.tsx
@@ -1,6 +1,5 @@
-import { MaterialIcons } from "@expo/vector-icons";
 import React from "react";
-import { TouchableOpacity, View } from "react-native";
+import { View } from "react-native";
 import { BigHead } from "react-native-bigheads";
 import styled from "styled-components/native";
 import { useTheme } from "../../contexts/ThemeContext";
@@ -19,56 +18,48 @@ const UserInfo = ({ handleClose, user }: Props) => {
   const { themeColors } = useTheme();
   const { deleteUser, currentUser } = useUser();
   return (
-    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 10, backgroundColor: "#00000090" }}>
-      <View style={{ width: "100%", backgroundColor: themeColors.deepPurple, borderRadius: 10 }}>
-        <Header themeColors={themeColors}>
-          <TouchableOpacity style={{ position: "absolute", top: "50%", right: 20 }} onPress={handleClose}>
-            <MaterialIcons name="close" size={32} color={themeColors.commons.white} />
-          </TouchableOpacity>
-          <StyledText themeColors={themeColors}>Selected user</StyledText>
-        </Header>
-        <View style={{ flexDirection: "row", margin: 12 }}>
-          <View style={{ flex: 1, backgroundColor: "blue", alignItems: "center", justifyContent: "center", padding: 8 }}>
-            <BigHead {...user.avatar} size={100} />
-            <InfoText themeColors={themeColors}>{user.username}</InfoText>
-          </View>
-          <View style={{ backgroundColor: "green", flex: 2, padding: 12 }}>
-            <STMText size={16} center uppercase>
-              stats
+    <>
+      <View style={{ flexDirection: "row", margin: 12 }}>
+        <View style={{ flex: 1, backgroundColor: "blue", alignItems: "center", justifyContent: "center", padding: 8 }}>
+          <BigHead {...user.avatar} size={100} />
+          <InfoText themeColors={themeColors}>{user.username}</InfoText>
+        </View>
+        <View style={{ backgroundColor: "green", flex: 2, padding: 12 }}>
+          <STMText size={16} center uppercase>
+            stats
+          </STMText>
+          <View style={{ backgroundColor: "teal" }}>
+            <STMText size={14} styles={{ padding: 4 }}>
+              Stat 1:
             </STMText>
-            <View style={{ backgroundColor: "teal" }}>
-              <STMText size={14} styles={{ padding: 4 }}>
-                Stat 1:
-              </STMText>
-              <STMText size={14} styles={{ padding: 4 }}>
-                Stat 2:
-              </STMText>
-              <STMText size={14} styles={{ padding: 4 }}>
-                Stat 3:
-              </STMText>
-            </View>
+            <STMText size={14} styles={{ padding: 4 }}>
+              Stat 2:
+            </STMText>
+            <STMText size={14} styles={{ padding: 4 }}>
+              Stat 3:
+            </STMText>
           </View>
         </View>
-        <ButtonContainer>
-          <ModalStandardButton
-            onPress={() => {
-              handleClose();
-              deleteUser(user);
-            }}
-            title="Delete"
-            color={themeColors.mustard}
-          />
-          <ModalStandardButton
-            onPress={() => {
-              handleClose();
-              console.log("edit user");
-            }}
-            title="Edit"
-            color={themeColors.mustard}
-          />
-        </ButtonContainer>
       </View>
-    </View>
+      <ButtonContainer>
+        <ModalStandardButton
+          onPress={() => {
+            handleClose();
+            deleteUser(user);
+          }}
+          title="Delete"
+          color={themeColors.mustard}
+        />
+        <ModalStandardButton
+          onPress={() => {
+            handleClose();
+            console.log("edit user");
+          }}
+          title="Edit"
+          color={themeColors.mustard}
+        />
+      </ButtonContainer>
+    </>
   );
 };
 

--- a/Screens/Home.tsx
+++ b/Screens/Home.tsx
@@ -1,7 +1,8 @@
 import { FontAwesome } from "@expo/vector-icons";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useEffect, useRef, useState } from "react";
-import { Modal, Pressable, View } from "react-native";
+import { Pressable } from "react-native";
+import { BigHead } from "react-native-bigheads";
 import { gestureHandlerRootHOC } from "react-native-gesture-handler";
 import { Modalize } from "react-native-modalize";
 import styled from "styled-components/native";
@@ -9,6 +10,7 @@ import { RootStackParams } from "../App";
 import Background from "../Components/Background";
 import HomeScreenButton from "../Components/Buttons/HomeScreenButton";
 import Logo from "../Components/Logo";
+import QuizModal from "../Components/Modal/QuizModal";
 import UserInfo from "../Components/User/UserInfo";
 import { useSound } from "../contexts/SoundContext";
 import { useTheme } from "../contexts/ThemeContext";
@@ -46,21 +48,13 @@ const HomeScreen = ({ navigation, route }: HomeNavigationProps) => {
     logOutUser();
   };
 
+  const headerImg = <BigHead {...currentUser?.avatar} size={40} />;
+
   return (
     <Background>
-      <View>
-        <Modal
-          statusBarTranslucent={true}
-          animationType="fade"
-          transparent={true}
-          visible={modalVisible}
-          onRequestClose={() => {
-            setModalVisible(!modalVisible);
-          }}
-        >
-          <UserInfo handleClose={() => setModalVisible(false)} user={currentUser ? currentUser : ({} as User)} />
-        </Modal>
-      </View>
+      <QuizModal show={modalVisible} closeModal={() => setModalVisible(false)} title={"selected user"} headerImg={headerImg}>
+        <UserInfo handleClose={() => setModalVisible(false)} user={currentUser ? currentUser : ({} as User)} />
+      </QuizModal>
       {/* logoutbutton */}
       <Pressable onPress={() => handleLogOut()} style={{ marginTop: 120, right: 60, position: "absolute", zIndex: 999 }}>
         <FontAwesome name="user-circle-o" size={24} color={themeColors.lightGrey} />

--- a/Screens/LogIn.tsx
+++ b/Screens/LogIn.tsx
@@ -1,3 +1,4 @@
+import { FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useEffect, useState } from "react";
 import { KeyboardAvoidingView, Platform, Text } from "react-native";
@@ -49,14 +50,28 @@ const LogInScreen = ({ navigation }: Props) => {
     loginUser(guestUser);
   };
 
+  const createUserHeaderImg = <FontAwesome5 name="user-plus" size={30} color={themeColors.commons.white} />;
+  const logInHeaderImg = <MaterialCommunityIcons name="login" size={30} color={themeColors.commons.white} />;
+
   return (
     <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === "ios" ? "padding" : "height"}>
       <Background>
-        <QuizModal show={createUserModalVisible} closeModal={() => setCreateUserModalVisible(false)} title={"create user"}>
+        <QuizModal
+          show={createUserModalVisible}
+          closeModal={() => setCreateUserModalVisible(false)}
+          title={"create user"}
+          headerImg={createUserHeaderImg}
+        >
           <CreateUser handleClose={() => setCreateUserModalVisible(false)} />
         </QuizModal>
 
-        <QuizModal show={loginModalVisible} closeModal={() => setLoginModalVisible(false)} title={"choose user"} modalHeight={"85%"}>
+        <QuizModal
+          show={loginModalVisible}
+          closeModal={() => setLoginModalVisible(false)}
+          title={"choose user"}
+          modalHeight={"85%"}
+          headerImg={logInHeaderImg}
+        >
           <UserExists handleLogIn={handleLogIn} />
         </QuizModal>
 


### PR DESCRIPTION
You can now pass any JSX element to the QuizModal "headerImg" parameter and it will show up on the left-hand side of the modal header. Mind the height and width of the element you pass in, optimal height is 30-40px and the width would depend on the width of the header title:

Examples:

Icon:
`const createUserHeaderImg = <FontAwesome5 name="user-plus" size={30} color={themeColors.commons.white} />;`
` <QuizModal  headerImg={createUserHeaderImg} ...Props > {content} </QuizModal>`
![image](https://user-images.githubusercontent.com/90193907/193427135-59f81576-b09f-419c-aaff-719cf31e67cf.png)

BigHead:
`const bigHeadHeaderImg = <BigHead {...currentUser?.avatar} size={40} />;`
`<QuizModal  headerImg={bigHeadHeaderImg} ...Props > {content} </QuizModal>`
![image](https://user-images.githubusercontent.com/90193907/193427275-3c63bfcf-7e2b-4b0e-bb3a-c30997ceb325.png)

PNG:
`import CSSImg from "../../assets/languageIcons/css-3.png";`
`const cssHeaderImg= <Image source={categoryImg} style={{ width: 40, height: 40 }} />;`
` <QuizModal  headerImg={cssHeaderImg} ...Props > {content} </QuizModal>`
![image](https://user-images.githubusercontent.com/90193907/193427309-88048990-0eff-477b-9ee6-ce8f7d6ffad0.png)


UserInfo now also uses QuizModal.




